### PR TITLE
Update repo.py

### DIFF
--- a/repo.py
+++ b/repo.py
@@ -2,9 +2,16 @@
 import os
 import base64
 import platform
-import argparse
 
 arch = platform.machine()
+
+def shellExec(command):
+    return int(os.system(command) / 256) # if shell exit status is 1, os.system will return 256
+def exec(command, error):
+    if shellExec(command) != 0:
+        print(error)
+        os._exit(1)
+
 
 def logo():
     print(" ____                 _     _                  _       _     _                  ")
@@ -37,133 +44,132 @@ def logo():
 
 def add_gpg_key():
     print('Installing GnuPG...')
-    os.system('sudo apt update && sudo apt install -y gnupg || error "Failed to install GnuPG!" ')
+    exec('sudo apt update && sudo apt install -y gnupg || exit 1', "Failed to install GnuPG!")
     print('Adding GPG key...')
-    os.system('wget -qO- https://raw.githubusercontent.com/raspbian-addons/raspbian-addons/master/KEY.gpg | sudo apt-key add - || error "Failed to add GPG key!"')
-    print('Creating package list... || error "Failed to create package list!"')
+    exec('wget -qO- https://raw.githubusercontent.com/raspbian-addons/raspbian-addons/master/KEY.gpg | sudo apt-key add - || exit 1', "Failed to add GPG key!")
+    print('Creating package list...')
 
 def update():
     print('Updating APT lists...')
-    os.system('sudo apt update || echo -e "\e[1;31mFailed to update APT lists!\e[0m" && exit 1')
+    exec('sudo apt update || exit 1', "Failed to update APT lists!")
     print('Done!')
-
 
 if __name__ == "__main__":
     copyright = logo()
 
     if copyright[0][10:13] != 'AgI' or copyright[1][17:20] != 'CBo':
-        print('Verification failed! Exit.')
+        print('Verification failed! Exiting.')
         os._exit(0)
 
     if arch != 'aarch64' and arch != 'armv7l':
         print('This script is only intended to run on ARM devices.\n')
-        os._exit(0)
+        os._exit(1)
 
 
     try:
         option = input('\nPlease select the action to be performed: ')
-    except  EOFError:
+    except EOFError:
         pass
 
     if int(option) == 1:
         add_gpg_key()
-        os.system('echo "deb http://storage.osdn.net/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb http://storage.osdn.net/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
 
     elif int(option) == 2:
         add_gpg_key()
-        os.system('echo "deb https://mirrors.xtom.com/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://mirrors.xtom.com/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 3:
         add_gpg_key()
-        os.system('echo "deb https://mirrors.gigenet.com/OSDN/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://mirrors.gigenet.com/OSDN/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 4:
         add_gpg_key()
-        os.system('echo "deb https://osdn.mirror.constant.com/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://osdn.mirror.constant.com/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 5:
         add_gpg_key()
-        os.system('echo "deb https://plug-mirror.rcac.purdue.edu/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://plug-mirror.rcac.purdue.edu/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 6:
         add_gpg_key()
-        os.system('echo "deb https://mirror.math.princeton.edu/pub/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://mirror.math.princeton.edu/pub/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 7:
         add_gpg_key()
-        os.system('echo "deb https://mirrors.tuna.tsinghua.edu.cn/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        os.system('echo "deb https://mirrors.tuna.tsinghua.edu.cn/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 8:
         add_gpg_key()
-        os.system('echo "deb https://mirrors.bfsu.edu.cn/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://mirrors.bfsu.edu.cn/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 9:
         add_gpg_key()
-        os.system('echo "deb https://mirror.sjtu.edu.cn/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://mirror.sjtu.edu.cn/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 10:
         add_gpg_key()
-        os.system('echo "deb https://mirrors.nju.edu.cn/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://mirrors.nju.edu.cn/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 11:
         add_gpg_key()
-        os.system('echo "deb https://mirror.xtom.com.hk/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://mirror.xtom.com.hk/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 12:
         add_gpg_key()
-        os.system('echo "deb https://free.nchc.org.tw/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://free.nchc.org.tw/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 13:
         add_gpg_key()
-        os.system('echo "deb https://ftp.iij.ad.jp/pub/osdn.jp/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://ftp.iij.ad.jp/pub/osdn.jp/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 14:
         add_gpg_key()
-        os.system('echo "deb https://ftp.jaist.ac.jp/pub/sourceforge.jp/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://ftp.jaist.ac.jp/pub/sourceforge.jp/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 15:
         add_gpg_key()
-        os.system('echo "deb https://ymu.dl.osdn.jp/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://ymu.dl.osdn.jp/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 16:
         add_gpg_key()
-        os.system('echo "deb https://ftp.acc.umu.se/mirror/osdn.net/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb https://ftp.acc.umu.se/mirror/osdn.net/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 17:
         add_gpg_key()
-        os.system('echo "deb http://ftp.halifax.rwth-aachen.de/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb http://ftp.halifax.rwth-aachen.de/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 18:
         add_gpg_key()
-        os.system('echo "deb http://mirrors.dotsrc.org/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb http://mirrors.dotsrc.org/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 19:
         add_gpg_key()
-        os.system('echo "deb http://ftp.onet.pl/pub/mirrors/sourceforge.jp/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb http://ftp.onet.pl/pub/mirrors/sourceforge.jp/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 20:
         add_gpg_key()
-        os.system('echo "deb http://mirror.liquidtelecom.com/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || error "Failed to create package list!"')
+        exec('echo "deb http://mirror.liquidtelecom.com/osdn/storage/g/r/ra/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/rpirepo.list || exit 1', "Failed to create package list!")
         update()
 
     elif int(option) == 21:


### PR DESCRIPTION
- Removed unused import (`argparse`).
- replaced all `os.system()` with a custom wrapper (`exec()`) that prints a error message provided if the return value of os.system() isn't 0. that fixes all the `os.system('command || error "command failed"')` (the `error` function isn't defined, so if that command fails the shell will just say something like this: `sh: error: command not found`.

#### how the `shellExec()` function works:
`os.system()` returns 256 if the shell returns 1, and 512 if it returns 2 etc. so by dividing the return value of `os.system()` by 256 we can get the real return value.

The functions are tested, and the script starts with no errors, but I haven't actually tested the parts that add the .list file as I'm currently running manjaro.